### PR TITLE
feature: 增加对iOS模拟器的支持

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,4 @@ node_modules/
 .DS_Store
 
 .vscode/
+.idea

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
 [submodule "ATX-WebDriverAgent"]
 	path = ATX-WebDriverAgent
 	url = https://github.com/openatx/WebDriverAgent
+
+[submodule "Appium-WebDriverAgent"]
+	path = Appium-WebDriverAgent
+	url = https://github.com/appium/WebDriverAgent

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,4 @@
 
 [submodule "Appium-WebDriverAgent"]
 	path = Appium-WebDriverAgent
-	url = https://github.com/appium/WebDriverAgent
+	url = https://github.com/appium/WebDriverAgent.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,6 @@
 
 [submodule "Appium-WebDriverAgent"]
 	path = Appium-WebDriverAgent
-	url = https://github.com/Vancheung/WebDriverAgent.git
+	url = https://github.com/Vancheung/WebDriverAgent
+[submodule]
+	Appium-WebDriverAgent = master

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,4 @@
 
 [submodule "Appium-WebDriverAgent"]
 	path = Appium-WebDriverAgent
-	url = https://github.com/appium/WebDriverAgent.git
+	url = https://github.com/Vancheung/WebDriverAgent.git

--- a/idb.py
+++ b/idb.py
@@ -293,7 +293,6 @@ class WDADevice(object):
         # check wda_status every 3
         
         
-        s
         fail_cnt = 0
         last_ip = self.device_ip
         while not self._stop.is_set():

--- a/idb.py
+++ b/idb.py
@@ -45,7 +45,7 @@ def list_devices():
     udids = [device.udid for device in devices]
     udid_sim = runcommand('xcrun', 'simctl', 'list', 'devices').splitlines()
     p = re.compile(r'[(](.*?)[)]', re.S)
-    udids.extend([re.findall(p, i)[0] for i in udid_sim if 'Booted' in i])
+    udids.extend([re.findall(p, i)[-2] for i in udid_sim if 'Booted' in i])
     return udids
 
 
@@ -290,7 +290,10 @@ class WDADevice(object):
         """
         check WebDriverAgent all the time
         """
-        # check wda_status every 30s
+        # check wda_status every 3
+        
+        
+        s
         fail_cnt = 0
         last_ip = self.device_ip
         while not self._stop.is_set():

--- a/idb.py
+++ b/idb.py
@@ -275,7 +275,6 @@ class WDADevice(object):
         # check wda_status every 3
         
         
-        s
         fail_cnt = 0
         last_ip = self.device_ip
         while not self._stop.is_set():

--- a/idb.py
+++ b/idb.py
@@ -5,6 +5,7 @@
 import base64
 import json
 import os
+import re
 import sys
 import subprocess
 import time
@@ -42,6 +43,9 @@ def runcommand(*args) -> str:
 def list_devices():
     devices = um.device_list()
     udids = [device.udid for device in devices]
+    udid_sim = runcommand('xcrun', 'simctl', 'list', 'devices').splitlines()
+    p = re.compile(r'[(](.*?)[)]', re.S)
+    udids.extend([re.findall(p, i)[0] for i in udid_sim if 'Booted' in i])
     return udids
 
 
@@ -51,7 +55,12 @@ def udid2name(udid: str) -> str:
         if device.udid == udid:
             d = Device(device.udid)
             return d.get_value(no_session=True).get('DeviceName')
-    return "Unknown"
+    if not devices:  # 模拟器
+        udid_sim = runcommand('xcrun', 'simctl', 'list', 'devices').splitlines()
+        for i in udid_sim:
+            if udid in i:
+                return i[:i.index('(')].strip()                
+    return "Unknown"    
 
 
 def udid2product(udid):
@@ -90,15 +99,24 @@ def udid2product(udid):
         "iPhone11,2": "iPhone XS",
         "iPhone11,4": "iPhone XS Max",
         "iPhone11,6": "iPhone XS Max",
-        "iPhone11,8": "iPhone XR",
         "iPhone12,1": "iPhone 11",
         "iPhone12,3": "iPhone 11 Pro",
         "iPhone12,5": "iPhone 11 Pro Max",
         "iPhone12,8": "iPhone SE 2nd",
+        "iPhone13,1": "iPhone 12 mini",
+        "iPhone13,2": "iPhone 12",
+        "iPhone13,3": "iPhone 12 Pro",
+        "iPhone13,4": "iPhone 12 Pro Max",
+        "iPhone14,2": "iPhone 13 Pro",
+        "iPhone14,3": "iPhone 13 Pro Max",        
+        "iPhone14,4": "iPhone 13 mini",        
+        "iPhone14,5": "iPhone 13",                
         # simulator
         "i386": "iPhone Simulator",
         "x86_64": "iPhone Simulator",
     }
+    if not pt:
+        pt = "i386"
     return models.get(pt, "Unknown")
 
 
@@ -325,13 +343,20 @@ class WDADevice(object):
             #    WebDriverAgentRunner-Runner.app encountered an error (Failed to install or launch the test
             #    runner. (Underlying error: Only directories may be uploaded. Please try again with a directory
             #    containing items to upload to the application_s sandbox.))
-            
+            self._wda_port = freeport.get()
+            self._mjpeg_port = freeport.get()
             cmd = [
                 'xcodebuild', '-project',
                 os.path.join(self.wda_directory, 'WebDriverAgent.xcodeproj'),
                 '-scheme', 'WebDriverAgentRunner', "-destination",
                 'id=' + self.udid, 'test'
             ]
+            if "Simulator" in self.product:  # 模拟器
+                cmd.extend([
+                    'USE_PORT=' + str(self._wda_port),
+                    'MJPEG_SERVER_PORT=' + str(self._mjpeg_port),
+                ])
+
             if os.getenv("TMQ") == "true":
                 cmd = ['tins', '-u', self.udid, 'xctest']
 
@@ -347,17 +372,15 @@ class WDADevice(object):
                 self.run_background(
                     cmd, stdout=subprocess.DEVNULL,
                     stderr=subprocess.STDOUT)  # cwd='Appium-WebDriverAgent')
-
-            self._wda_port = freeport.get()
-            self._mjpeg_port = freeport.get()
-            self.run_background(
-                ["tidevice", '-u', self.udid, 'relay',
-                 str(self._wda_port), "8100"],
-                silent=True)
-            self.run_background(
-                ["tidevice", '-u', self.udid, 'relay',
-                 str(self._mjpeg_port), "9100"],
-                silent=True)
+            if "Simulator" not in self.product:
+                self.run_background(
+                    ["tidevice", '-u', self.udid, 'relay',
+                     str(self._wda_port), "8100"],
+                    silent=True)
+                self.run_background(
+                    ["tidevice", '-u', self.udid, 'relay',
+                     str(self._mjpeg_port), "9100"],
+                    silent=True)
 
             self.restart_wda_proxy()
             return await self.wait_until_ready()

--- a/idb.py
+++ b/idb.py
@@ -41,7 +41,7 @@ def list_devices():
     udids = runcommand('idevice_id', '-l').splitlines()
     udid_sim = runcommand('xcrun', 'simctl', 'list', 'devices').splitlines()
     p = re.compile(r'[(](.*?)[)]', re.S)
-    udids.extend([re.findall(p, i)[0] for i in udid_sim if 'Booted' in i])
+    udids.extend([re.findall(p, i)[-2] for i in udid_sim if 'Booted' in i])
     return udids
 
 
@@ -272,7 +272,10 @@ class WDADevice(object):
         """
         check WebDriverAgent all the time
         """
-        # check wda_status every 30s
+        # check wda_status every 3
+        
+        
+        s
         fail_cnt = 0
         last_ip = self.device_ip
         while not self._stop.is_set():

--- a/wdaproxy-script.py
+++ b/wdaproxy-script.py
@@ -108,7 +108,7 @@ class ScreenWSHandler(CorsMixin, WebSocketHandler):
 
 # Ref: https://github.com/colevscode/quickproxy/blob/master/quickproxy/proxy.py
 class ReverseProxyHandler(CorsMixin, tornado.web.RequestHandler):
-    _default_http_client = httpx.AsyncClient()
+    _default_http_client = httpx.AsyncClient(timeout=60)
     TARGET_URL = None
 
     async def handle_request(self, request):


### PR DESCRIPTION
1. 支持获取模拟器列表命令：：xcrun simctl list devices
2. 在list_devices()、udid2name()方法中支持获取已启动的模拟器udid、名称
3. 在udid2product()方法中增加iPhone 12 机型，且在ideviceinfo获取不到ProductType时返回iPhone Simulator
4. 调整run_webdriveragent方法，先指定self._wda_port和self._mjpeg_port，如果设备类型为模拟器，则xcodebuild wda时增加['USE_PORT=' + str(self._wda_port), 'MJPEG_SERVER_PORT=' + str(self._mjpeg_port)]，且无需执行./iproxy.sh