### PR TITLE
fix: 调大 wda 代理超时时间设置, 解决很多触碰操作因为超时引起500,导致操作卡住问题

### DIFF
--- a/wdaproxy-script.py
+++ b/wdaproxy-script.py
@@ -108,7 +108,8 @@ class ScreenWSHandler(CorsMixin, WebSocketHandler):
 
 # Ref: https://github.com/colevscode/quickproxy/blob/master/quickproxy/proxy.py
 class ReverseProxyHandler(CorsMixin, tornado.web.RequestHandler):
-    _default_http_client = httpx.AsyncClient()
+    # 超时时间手动设长，避免一些耗时操作（如获取元素树）直接超时失败
+    _default_http_client = httpx.AsyncClient(timeout=30.0)
     TARGET_URL = None
 
     async def handle_request(self, request):


### PR DESCRIPTION
实际使用发现 wda 无法保障大部分操作都5秒内返回，所以超时时间改为30秒，缓解经常遇到的 httpcore.ReadTimeout 错误，以及因此引起的触碰操作经常会卡住的问题。